### PR TITLE
fix: omit self entry on related posts

### DIFF
--- a/src/templates/BlogEntry.js
+++ b/src/templates/BlogEntry.js
@@ -56,6 +56,7 @@ export const pageQuery = graphql`
   query BlogPostQuery($id: String, $tags: [String]) {
     related: allMdx(
       filter: {
+        id: { ne: $id }
         frontmatter: { tags: { in: $tags }, status: { eq: "published" } }
       }
       limit: 3


### PR DESCRIPTION
## Descripción

Había un pequeño bug que no ví a la primera, y es que en los posts relacionados en ocasiones salía el mismo posts en el que ya estabas. Esto obviamente es no deseado, y con esta adición al filtro debe resolverse

## Related Issues

#81 